### PR TITLE
Fix for inconsistent behaviour

### DIFF
--- a/tinder.user.js
+++ b/tinder.user.js
@@ -27,12 +27,15 @@ async function unblur() {
 	}
 }
 
-async function once(listener, event) {
+async function waitForApp() {
 	return new Promise((resolve) => {
-		listener.addEventListener(event, () => {
-			listener.removeEventListener(event, resolve);
-			resolve();
-		});
+		new MutationObserver((_, me) => {
+			let appEl = document.querySelector('.App');
+			if (appEl) {
+				me.disconnect();
+				resolve(appEl);
+			}
+		}).observe(document, { subtree: true, childList: true });
 	});
 }
 
@@ -48,10 +51,9 @@ async function main() {
 	}
 
 	// wait for a full page load
-	await once(window, 'load');
+	const appEl = await waitForApp();
 
 	// setup navigation observer
-	const appEl = document.querySelector('.App');
 	const observer = new MutationObserver(() => {
 		if (['/app/likes-you', '/app/gold-home'].includes(location.pathname)) {
 			unblur();


### PR DESCRIPTION
Hi, I've noticed your `once` function was a bit inconsistent when it comes to waiting for the DOM element with the class ".App".
To reproduce, add a `console.log` after `const appEl = document.querySelector('.App');` and log the element queried. Sometimes this is a valid element, other times, it is `null` because it is not yet loaded.
I have a fix for this using MutationObserver.

Some explanation why I think this is an issue:
Your approach using an event listener would be correct if Tinder was a normal JavaScript page.
But it turns out they're using ReactJS (or maybe some other framework like that; I don't know, they're using webpack to compile) for managing the DOM.
Because of this, the event listener for "load" may fire once the page has indeed fully loaded, but before React had a chance to alter the page and create the DOM element we're looking for.

What's different?
Instead of an event listener, using a MutationObserver assures us the element we're looking for exists.
In the mutation observer, I'm querying for the App element and when it is found, I disconnect the observer (basically stopping any future observations since we need this only once) and then resolving the promise with the element found.

Feel free to edit any naming conventions and add comments as you feel necessary